### PR TITLE
Attempt to resize image buffer if image is over API image size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Additionally you can set these environment variables to customize behavior:
 - `MIN_DATE` = indicates the minimum date of posts to import, ISO format (e.g. '2011-01-01' or '2011-02-09T10:30:49.000Z').
 - `MAX_DATE` = indicates the maximum date of posts to import, ISO format (e.g. '2012-01-01' or '2014-04-09T12:36:49.328Z').
 
+### Notes
+The Bluesky has an upload limit of 1mb for image files. The script will check images that are over 1mb and if they are will scale the longest edge of the image down to 1920px. Which in most cases will decrease the image filesize below 1mb. In cases where its still too big, the image will be skipped. 
+
 ## License
 
 "Instagram To Bluesky" is published under the MIT license.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Additionally you can set these environment variables to customize behavior:
 - `MAX_DATE` = indicates the maximum date of posts to import, ISO format (e.g. '2012-01-01' or '2014-04-09T12:36:49.328Z').
 
 ### Notes
-The Bluesky has an upload limit of 1mb for image files. The script will check images that are over 1mb and if they are will scale the longest edge of the image down to 1920px. Which in most cases will decrease the image filesize below 1mb. In cases where its still too big, the image will be skipped. 
+The Bluesky API has an upload limit of 1mb for image files. The script will check images that are over 1mb and if they are will scale the longest edge of the image down to 1920px. Which in most cases will decrease the image filesize below 1mb. In cases where its still too big, the image will be skipped. 
 
 ## License
 

--- a/app.ts
+++ b/app.ts
@@ -298,7 +298,7 @@ async function processMedia(media) {
 
       if (bufferResized.length > API_LIMIT_IMAGE_UPLOAD_SIZE) {
         logger.error({
-          message: `Resized image size (${byteSize(bufferResized.length)}) larger than image upload limit (${byteSize(API_LIMIT_IMAGE_UPLOAD_SIZE)})`
+          message: `Resized image size (${byteSize(bufferResized.length)}) is larger than image upload limit (${byteSize(API_LIMIT_IMAGE_UPLOAD_SIZE)})`
         });
         return { mediaText: '', mimeType: null, imageBuffer: null };
       }

--- a/app.ts
+++ b/app.ts
@@ -7,7 +7,6 @@ import sharp from 'sharp';
 import byteSize from 'byte-size';
 
 import { AtpAgent, RichText } from '@atproto/api';
-import { buffer } from 'stream/consumers';
 
 const logger = pino({
   transport: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "instagramtobluesky",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instagramtobluesky",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@atproto/api": "^0.13.31",
+        "byte-size": "^9.0.1",
         "dotenv": "^16.4.7",
         "luxon": "^3.5.0",
         "pino": "^9.6.0",
@@ -474,6 +475,23 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
       "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw=="
+    },
+    "node_modules/byte-size": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-9.0.1.tgz",
+      "integrity": "sha512-YLe9x3rabBrcI0cueCdLS2l5ONUKywcRpTs02B8KP9/Cimhj7o3ZccGrPnRvcbyHMbb7W79/3MUJl7iGgTXKEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instagramtobluesky",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Import Instagram archive to a Bluesky account",
   "main": "app.js",
   "engines": {
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@atproto/api": "^0.13.31",
+    "byte-size": "^9.0.1",
     "dotenv": "^16.4.7",
     "luxon": "^3.5.0",
     "pino": "^9.6.0",


### PR DESCRIPTION
I've had a few instances in my archive of images being over the API image upload limit which is 1mb, although the API appears to throw an error if files are over 976kb.

Have added some logic to resize the buffer images largest side length to a max of 1920 (based on observing the output of images the bsky web app). This should work in most cases, but admitedly, there's a chance that a 1920 x 1920 image could be over files size.

Have added logging to let users know whats going on.

Conversation about upping the API image limit is is here:
https://github.com/bluesky-social/atproto/discussions/1740

I appreciate this might be a somewhat opinionated change, so no worries if you want to deny the PR