### PR TITLE
Add graceful handling of fetching image aspect ratio via try catch 

### DIFF
--- a/src/image/image.ts
+++ b/src/image/image.ts
@@ -109,10 +109,15 @@ export async function processImageBuffer(mediaBuffer: Buffer, filename: string):
 }
 
 export async function getImageSize(filePath: string): Promise<Ratio | null> {
-  let image = sharp(filePath);
-  const metadata = await image.metadata();
-  if( metadata.width != undefined && metadata.height != undefined)
-    return { width: metadata.width, height: metadata.height };
-  else
-    return null;
+  let ratio: Ratio | null = null;
+  try {
+    let image = sharp(filePath);
+    const metadata = await image.metadata();
+    if( metadata.width != undefined && metadata.height != undefined)
+      ratio = { width: metadata.width, height: metadata.height };
+  } catch (error) {
+    logger.error(`Failed to get image aspect ratio; image path: ${filePath}, error: ${error}`)
+  }
+
+  return ratio;
 }

--- a/src/media/media.test.ts
+++ b/src/media/media.test.ts
@@ -452,14 +452,20 @@ describe("getImageSize", () => {
     expect(result).toBeNull();
   });
 
-  test("should handle errors when file is missing", async () => {
-    try {
-      await getImageSize("/path/to/missing.jpg");
-      // If we reach here, the test should fail
-      expect(true).toBe(false);
-    } catch (error) {
-      expect(error).toBeDefined();
-      expect((error as Error).message).toContain("Input file is missing");
-    }
+  test("should log error when image processing fails", async () => {
+    // Import the logger mock
+    const { logger } = require("../logger/logger");
+    
+    // Call the function with a path that will trigger an error
+    const result = await getImageSize("/path/to/missing.jpg");
+    
+    // Verify the logger.error was called with the expected message pattern
+    expect(logger.error).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/Failed to get image aspect ratio; image path: \/path\/to\/missing\.jpg, error:/)
+    );
+    
+    // Verify the function returns null when an error occurs
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
Add logging so our reporter can show us what file types are not accepted.