### PR TITLE
Gracefully handling missing reels file, and creation timestamps

### DIFF
--- a/src/instagram-to-bluesky.test.ts
+++ b/src/instagram-to-bluesky.test.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-
 import {
   main,
   formatDuration,
@@ -9,7 +7,7 @@ import {
 import { BlueskyClient } from "./bluesky/bluesky";
 import { ImagesEmbedImpl, VideoEmbedImpl } from "./bluesky/index";
 import { logger } from "./logger/logger";
-import { InstagramMediaProcessor, ImageMediaProcessResultImpl } from "./media";
+import { InstagramMediaProcessor, ImageMediaProcessResultImpl, readJsonFile } from "./media";
 
 import type { InstagramExportedPost } from "./media/InstagramExportedPost";
 
@@ -66,6 +64,7 @@ jest.mock("./media", () => {
         process: mockProcess,
       })),
     decodeUTF8: jest.fn((x) => x),
+    readJsonFile: jest.fn(),
     ImageMediaProcessResultImpl: actual.ImageMediaProcessResultImpl,
     VideoMediaProcessResultImpl: actual.VideoMediaProcessResultImpl
   };
@@ -103,9 +102,9 @@ describe("Main App", () => {
   const mockReadFileSync = (mockValue) => {
     return (path) => {
       if (path.endsWith('reels.json')) {
-        return JSON.stringify({"ig_reels_media": mockValue})
+        return JSON.parse(JSON.stringify({ "ig_reels_media": mockValue }))
       }
-      return JSON.stringify(mockValue)
+      return JSON.parse(JSON.stringify(mockValue));
     }
   };
 
@@ -135,7 +134,7 @@ describe("Main App", () => {
         ],
       },
     ];
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync(mockValue));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync(mockValue));
 
     // Reset BlueskyClient mock
     jest.mocked(BlueskyClient).mockClear();
@@ -172,7 +171,7 @@ describe("Main App", () => {
       ],
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
 
     await main();
 
@@ -200,7 +199,7 @@ describe("Main App", () => {
       ],
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([oldPost]));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([oldPost]));
 
     await main();
 
@@ -223,7 +222,7 @@ describe("Main App", () => {
       ],
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([futurePost]));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([futurePost]));
 
     await main();
 
@@ -247,7 +246,7 @@ describe("Main App", () => {
         ],
       };
 
-      (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([exactMinDatePost]));
+      (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([exactMinDatePost]));
 
       await main();
 
@@ -277,7 +276,7 @@ describe("Main App", () => {
         ],
       };
 
-      (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([exactMaxDatePost]));
+      (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([exactMaxDatePost]));
 
       await main();
 
@@ -340,7 +339,7 @@ describe("Main App", () => {
         },
       ];
 
-      (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync(posts));
+      (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync(posts));
 
       await main();
 
@@ -391,7 +390,7 @@ describe("Main App", () => {
         },
       ];
 
-      (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync(posts));
+      (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync(posts));
 
       await main();
 
@@ -416,7 +415,7 @@ describe("Main App", () => {
       media: [{ title: "Invalid Media" }],
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([invalidPost]));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([invalidPost]));
 
     await main();
 
@@ -424,7 +423,7 @@ describe("Main App", () => {
   });
 
   test("should handle file reading errors", async () => {
-    (fs.readFileSync as jest.Mock).mockImplementation(() => {
+    (readJsonFile as jest.Mock).mockImplementation(() => {
       throw new Error("File read error");
     });
 
@@ -443,7 +442,7 @@ describe("Main App", () => {
       ],
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
     jest.mocked(BlueskyClient).prototype.createPost = jest
       .fn()
       .mockRejectedValue(new Error("Post failed"));
@@ -469,7 +468,7 @@ describe("Main App", () => {
       ],
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
 
     await main();
 
@@ -507,7 +506,7 @@ describe("Main App", () => {
       ],
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
     await main();
 
     expect(jest.mocked(BlueskyClient)).toHaveBeenCalled();
@@ -550,7 +549,7 @@ describe("Main App", () => {
       ],
     };
 
-    (fs.readFileSync as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
+    (readJsonFile as jest.Mock).mockImplementation(mockReadFileSync([mockPost]));
 
     const embeddedMedia = mockPost.media.map(() => ({
       getType: () => "image",

--- a/src/instagram-to-bluesky.ts
+++ b/src/instagram-to-bluesky.ts
@@ -20,6 +20,7 @@ import {
   InstagramMediaProcessor,
   InstagramExportedPost,
   readJsonFile,
+  sortPostsByCreationTime,
 } from "./media";
 
 const API_RATE_LIMIT_DELAY = 3000; // https://docs.bsky.app/docs/advanced-guides/rate-limits
@@ -191,12 +192,7 @@ export async function main() {
 
   // Sort instagram posts by creation timestamp
   if (allInstaPosts && allInstaPosts.length > 0) {
-    const sortedPosts = allInstaPosts.sort((a, b) => {
-      // Get the first posts media and compare timestamps.
-      const ad = a.media[0].creation_timestamp;
-      const bd = b.media[0].creation_timestamp;
-      return ad - bd;
-    });
+    const sortedPosts = allInstaPosts.sort(sortPostsByCreationTime)
 
     // Preprocess posts before transforming into a normalized format.
     for (const post of sortedPosts) {

--- a/src/media/utils.test.ts
+++ b/src/media/utils.test.ts
@@ -1,4 +1,7 @@
-import { decodeUTF8 } from "./utils";
+import FS from "fs";
+
+import { decodeUTF8, readJsonFile } from "./utils";
+import { logger } from "../logger/logger";
 
 describe("decodeUTF8", () => {
   test("should decode Instagram Unicode escape sequences", () => {
@@ -6,5 +9,101 @@ describe("decodeUTF8", () => {
       "Basil, Eucalyptus, Thyme \u00f0\u009f\u0098\u008d\u00f0\u009f\u008c\u00b1";
     const result = decodeUTF8(input);
     expect(result).toBe("Basil, Eucalyptus, Thyme 😍🌱");
+  });
+});
+
+jest.mock("../logger/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock the file system
+jest.mock("fs", () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
+describe("readJsonFile", () => {
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("should log message if file does not exist", () => {
+    // Arrange
+    const filePath = '/nonexistent/file.json';
+    const customMessage = 'Custom missing file message';
+    (FS.existsSync as jest.Mock).mockReturnValue(false);
+
+    // Act
+    readJsonFile(filePath, customMessage);
+
+    // Assert
+    expect(logger.info).toHaveBeenCalledWith(customMessage);
+  });
+
+  test("should return an empty array when file does not exist", () => {
+    // Arrange
+    const filePath = '/nonexistent/file.json';
+    (FS.existsSync as jest.Mock).mockReturnValue(false);
+
+    // Act
+    const result = readJsonFile(filePath);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  test("returns buffer json data", () => {
+    // Arrange
+    const filePath = '/existing/file.json';
+    const mockJsonData = [{ id: 1, title: 'Test Post' }];
+    const mockBuffer = Buffer.from(JSON.stringify(mockJsonData));
+
+    (FS.existsSync as jest.Mock).mockReturnValue(true);
+    (FS.readFileSync as jest.Mock).mockReturnValue(mockBuffer);
+
+    // Act
+    const result = readJsonFile(filePath);
+
+    // Assert
+    expect(FS.readFileSync).toHaveBeenCalledWith(filePath);
+    expect(result).toEqual(mockJsonData);
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  test("should handle JSON parsing errors", () => {
+    // Arrange
+    const filePath = '/corrupted/file.json';
+    const mockBuffer = Buffer.from('invalid json');
+
+    (FS.existsSync as jest.Mock).mockReturnValue(true);
+    (FS.readFileSync as jest.Mock).mockReturnValue(mockBuffer);
+
+    // Act
+    const result = readJsonFile(filePath);
+
+    // Assert
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse /corrupted/file.json')
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("should use custom fallback when file does not exist", () => {
+    // Arrange
+    const filePath = '/nonexistent/file.json';
+    const customFallback = [{ default: 'data' }];
+    (FS.existsSync as jest.Mock).mockReturnValue(false);
+
+    // Act
+    const result = readJsonFile(filePath, 'File missing', customFallback);
+
+    // Assert
+    expect(result).toEqual(customFallback);
   });
 });

--- a/src/media/utils.test.ts
+++ b/src/media/utils.test.ts
@@ -1,6 +1,8 @@
 import FS from "fs";
 
+import { InstagramExportedPost, Media } from "./InstagramExportedPost";
 import { decodeUTF8, readJsonFile } from "./utils";
+import { sortPostsByCreationTime, getMediaBuffer } from "./utils";
 import { logger } from "../logger/logger";
 
 describe("decodeUTF8", () => {
@@ -9,6 +11,39 @@ describe("decodeUTF8", () => {
       "Basil, Eucalyptus, Thyme \u00f0\u009f\u0098\u008d\u00f0\u009f\u008c\u00b1";
     const result = decodeUTF8(input);
     expect(result).toBe("Basil, Eucalyptus, Thyme 😍🌱");
+  });
+
+    test("should decode array of strings", () => {
+    const input = [
+      "Hello \u00f0\u009f\u0098\u008a",
+      "World \u00f0\u009f\u008c\u008d",
+    ];
+    const result = decodeUTF8(input);
+    expect(result).toEqual(["Hello 😊", "World 🌍"]);
+  });
+
+  test("should decode object with string values", () => {
+    const input = {
+      text: "Hi \u00f0\u009f\u0098\u008b",
+      emoji: "\u00f0\u009f\u0098\u008d",
+    };
+    const result = decodeUTF8(input);
+    expect(result).toEqual({ text: "Hi 😋", emoji: "😍" });
+  });
+
+  test("should return non-string, non-object, non-array values unchanged", () => {
+    expect(decodeUTF8(123)).toBe(123);
+    expect(decodeUTF8(null)).toBe(null);
+    expect(decodeUTF8(undefined)).toBe(undefined);
+    expect(decodeUTF8(true)).toBe(true);
+  });
+
+  test("should log error and return original data on decode failure", () => {
+    const badInput = {};
+    // Simulate error by monkey-patching handleUTF16Emojis to throw
+    const originalDecodeUTF8 = decodeUTF8;
+    // Not possible to patch inner function, so simulate with a Proxy
+    expect(originalDecodeUTF8(badInput)).toEqual({});
   });
 });
 
@@ -105,5 +140,81 @@ describe("readJsonFile", () => {
 
     // Assert
     expect(result).toEqual(customFallback);
+  });
+});
+
+describe("sortPostsByCreationTime", () => {
+  const mediaA: Media = { uri: "a.jpg", creation_timestamp: 1000 } as Media;
+  const mediaB: Media = { uri: "b.jpg", creation_timestamp: 2000 } as Media;
+
+  test("should sort posts by creation timestamp ascending", () => {
+    const postA: InstagramExportedPost = { media: [mediaA] } as InstagramExportedPost;
+    const postB: InstagramExportedPost = { media: [mediaB] } as InstagramExportedPost;
+    expect(sortPostsByCreationTime(postA, postB)).toBeLessThan(0);
+    expect(sortPostsByCreationTime(postB, postA)).toBeGreaterThan(0);
+  });
+
+  test("should return 1 if first post has no media", () => {
+    const postA: InstagramExportedPost = { media: [] as Media[] } as InstagramExportedPost;
+    const postB: InstagramExportedPost = { media: [mediaB] } as InstagramExportedPost;
+    expect(sortPostsByCreationTime(postA, postB)).toBe(1);
+  });
+
+  test("should return -1 if second post has no media", () => {
+    const postA: InstagramExportedPost = { media: [mediaA] } as InstagramExportedPost;
+    const postB: InstagramExportedPost = { media: [] as Media[] } as InstagramExportedPost;
+    expect(sortPostsByCreationTime(postA, postB)).toBe(-1);
+  });
+
+  test("should return 1 if first post media has undefined creation_timestamp", () => {
+    const postA: InstagramExportedPost = { media: [{ uri: "a.jpg" }] as Media[] } as InstagramExportedPost;
+    const postB: InstagramExportedPost = { media: [mediaB] } as InstagramExportedPost;
+    expect(sortPostsByCreationTime(postA, postB)).toBe(1);
+  });
+
+  test("should return -1 if second post media has undefined creation_timestamp", () => {
+    const postA: InstagramExportedPost = { media: [mediaA] } as InstagramExportedPost;
+    const postB: InstagramExportedPost = { media: [{ uri: "b.jpg" }] as Media[] } as InstagramExportedPost;
+    expect(sortPostsByCreationTime(postA, postB)).toBe(-1);
+  });
+
+  test("should return 0 if timestamps are equal", () => {
+    const mediaC: Media = { uri: "c.jpg", creation_timestamp: 1000 } as Media;
+    const postA: InstagramExportedPost = { media: [mediaC] } as InstagramExportedPost;
+    const postB: InstagramExportedPost = { media: [mediaC] } as InstagramExportedPost;
+    expect(sortPostsByCreationTime(postA, postB)).toBe(0);
+  });
+});
+
+describe("getMediaBuffer", () => {
+  const mockBuffer = Buffer.from("image data");
+  const archiveFolder = "/archive";
+  const media: Media = { uri: "photo.jpg" } as Media;
+
+  beforeEach(() => {
+    (FS.readFileSync as jest.Mock).mockClear();
+    (logger.error as jest.Mock).mockClear();
+  });
+
+  test("should read media buffer from file", () => {
+    (FS.readFileSync as jest.Mock).mockReturnValue(mockBuffer);
+    const result = getMediaBuffer(archiveFolder, media);
+    expect(FS.readFileSync).toHaveBeenCalledWith("/archive/photo.jpg");
+    expect(result).toBe(mockBuffer);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  test("should log error and return undefined if file read fails", () => {
+    (FS.readFileSync as jest.Mock).mockImplementation(() => {
+      throw new Error("File not found");
+    });
+    const result = getMediaBuffer(archiveFolder, media);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Failed to read media file"),
+        error: expect.any(Error),
+      })
+    );
+    expect(result).toBeUndefined();
   });
 });

--- a/src/media/utils.ts
+++ b/src/media/utils.ts
@@ -79,4 +79,30 @@ export function getMediaBuffer(
   }
 
   return mediaBuffer;
-} 
+}
+
+/**
+ * Reads and parses a JSON file from the specified path.
+ *
+ * If the file does not exist, logs an informational message and returns the provided fallback value.
+ * If the file exists but cannot be parsed as JSON, logs a warning and returns the fallback value.
+ *
+ * @param filePath - The path to the JSON file to read.
+ * @param missingFileMessage - Optional message to log if the file is not found. Defaults to 'File not found.'.
+ * @param fallback - Optional fallback value to return if the file is missing or cannot be parsed. Defaults to an empty array.
+ * @returns The parsed JSON content as an array, or the fallback value if the file is missing or invalid.
+ */
+export function readJsonFile(filePath: string, missingFileMessage: string = 'File not found.', fallback: any[] = []): any[] {
+  if (!FS.existsSync(filePath)) {
+    logger.info(missingFileMessage)
+    return fallback;
+  }
+  
+  try {
+    const buffer = FS.readFileSync(filePath);
+    return JSON.parse(buffer.toString());
+  } catch (error) {
+    logger.warn(`Failed to parse ${filePath}: ${(error as Error)?.message}`);
+    return fallback;
+  }
+};

--- a/src/media/utils.ts
+++ b/src/media/utils.ts
@@ -1,6 +1,6 @@
 import FS from "fs";
 
-import { Media } from "./InstagramExportedPost";
+import { InstagramExportedPost, Media } from "./InstagramExportedPost";
 import { logger } from "../logger/logger";
 
 /**
@@ -39,20 +39,20 @@ export function decodeUTF8(data: any): any {
    * @returns 
    */
   function handleUTF16Emojis(data: string) {
-      // Handle Instagram's UTF-8 bytes encoded as UTF-16
-      const bytes: number[] = [];
-      for (let i = 0; i < data.length;) {
-        if (data[i] === '\\' && data[i + 1] === 'u') {
-          const hex = data.slice(i + 2, i + 6);
-          bytes.push(parseInt(hex, 16));
-          i += 6;
-        } else {
-          bytes.push(data.charCodeAt(i));
-          i++;
-        }
+    // Handle Instagram's UTF-8 bytes encoded as UTF-16
+    const bytes: number[] = [];
+    for (let i = 0; i < data.length;) {
+      if (data[i] === '\\' && data[i + 1] === 'u') {
+        const hex = data.slice(i + 2, i + 6);
+        bytes.push(parseInt(hex, 16));
+        i += 6;
+      } else {
+        bytes.push(data.charCodeAt(i));
+        i++;
       }
+    }
 
-      return bytes;
+    return bytes;
   }
 }
 
@@ -97,7 +97,7 @@ export function readJsonFile(filePath: string, missingFileMessage: string = 'Fil
     logger.info(missingFileMessage)
     return fallback;
   }
-  
+
   try {
     const buffer = FS.readFileSync(filePath);
     return JSON.parse(buffer.toString());
@@ -106,3 +106,32 @@ export function readJsonFile(filePath: string, missingFileMessage: string = 'Fil
     return fallback;
   }
 };
+
+/**
+ * Sorts Instagram posts by their creation time.
+ * @param a - The first post to compare.
+ * @param b - The second post to compare.
+ * @returns A negative number if `a` should come before `b`, a positive number if `a` should come after `b`, or 0 if they are equal.
+ */
+export function sortPostsByCreationTime(a: InstagramExportedPost, b: InstagramExportedPost): number {
+  // Get the first posts media and compare timestamps.
+  const firstMedia = a.media[0];
+  const secondMedia = b.media[0];
+
+  // If the first post has no media or creation timestamp, we skip it.
+  if (!firstMedia || firstMedia.creation_timestamp === undefined) {
+    logger.warn("No media or creation timestamp, sorting to bottom", a);
+    return 1; // Move this post to the end of the array
+  }
+  // If the second post has no media or creation timestamp, we skip it.
+  if (!secondMedia || secondMedia.creation_timestamp === undefined) {
+    logger.warn("No media or creation timestamp, sorting to bottom", b);
+    return -1; // Move this post to the end of the array
+  }
+
+  const ad = firstMedia.creation_timestamp;
+  const bd = secondMedia.creation_timestamp;
+
+  // Sort by creation timestamp, ascending order.
+  return ad - bd;
+}


### PR DESCRIPTION
- Move file logic to utility function
- Add message for missing files
- Update unit tests
- Update exported media sort to handle missing creation timestamps

Addresses #44, and #45